### PR TITLE
Implement HostReview ui-state and controller.

### DIFF
--- a/crossroads.net/app/group_finder/dashboard/dashboard.html
+++ b/crossroads.net/app/group_finder/dashboard/dashboard.html
@@ -1,6 +1,6 @@
 <div class="page-header">
   <div class="pull-right">
-    <a class="btn btn-warning" href="#" ui-sref="brave.welcome">Start Over</a>
+    <a class="btn btn-warning" href="#" ui-sref="brave.summary">Start Over</a>
   </div>
   <h2>Your Groups</h2>
 </div>

--- a/crossroads.net/app/group_finder/group_finder.routes.js
+++ b/crossroads.net/app/group_finder/group_finder.routes.js
@@ -64,9 +64,27 @@
 
       })
 
+      .state(seriesPermalink + '.host_review', {
+        controller: 'HostReviewCtrl as host',
+        url: '/host/review',
+        templateUrl: 'host/review.html',
+        resolve: {
+          QuestionService: require('./services/group_questions.service'),
+          questions: function(QuestionService) {
+            return QuestionService.get().$promise;
+          }
+        },
+        data: {
+          meta: {
+            title: seriesTitle,
+            description: ''
+          }
+        }
+      })
+
       .state(seriesPermalink + '.host', {
         controller: 'HostCtrl as host',
-        url: '/host/:step',
+        url: '/host/{step:(?:[0-9])}',
         templateUrl: 'host/host.html',
         resolve: {
           QuestionService: require('./services/group_questions.service'),
@@ -81,6 +99,7 @@
           }
         }
       })
+
     ;
 
     $urlRouterProvider.otherwise('/' + seriesPermalink + '/welcome');

--- a/crossroads.net/app/group_finder/host/host.controller.js
+++ b/crossroads.net/app/group_finder/host/host.controller.js
@@ -21,17 +21,17 @@
 
     // Properties
     vm.questions = QuestionDefinitions.questions;
-    vm.total_questions = _.size(vm.questions);
+    vm.totalQuestions = _.size(vm.questions);
     vm.currentIteration = parseInt($stateParams.step) || 1;
     vm.responses = Responses.data;
 
     // Methods
-    vm.previous = function(){
+    vm.previousQuestion = function(){
       vm.currentIteration--;
       $state.go('brave.host', { step: vm.currentIteration });
     };
 
-    vm.next_question = function(){
+    vm.nextQuestion = function(){
       var req = vm.currentQuestion().required === true;
       if (req && vm.responses[vm.currentQuestion().model][vm.currentKey()] === undefined) {
         $window.alert('required');
@@ -52,7 +52,6 @@
     vm.startOver = function(){
       vm.currentIteration = 1;
     };
-
   }
 
 })();

--- a/crossroads.net/app/group_finder/host/host.html
+++ b/crossroads.net/app/group_finder/host/host.html
@@ -5,15 +5,7 @@
 <div class="question" ng-repeat="(key, question) in host.questions track by $index" ng-show="(host.currentIteration-1)==$index">
   <question definition="question" responses="host.responses"></question>
   <hr />
-  <a href="#" class="btn btn-link" ng-hide="$index==0" ng-click="host.previous()">Go Back</a>
-  <button type="submit" class="btn btn-primary" ng-click="host.next_question()">Next</button>
-</div>
-
-<div class="review" ng-show="(host.currentIteration-1)==host.total_questions">
-  <p>Are your answers all correct?</p>
-  <pre>{{host.responses}}</pre>
-  <div class="btns">
-    <a class="btn btn-primary" href="#" ui-sref="brave.dashboard">Yes, this is correct</a>
-    <a class="btn btn-warning" href="#" ng-click="host.startOver()">No, I need to make some changes</a>
-  </div>
+  <a href="#" class="btn btn-link" ng-hide="$index==0" ng-click="host.previousQuestion()">Go Back</a>
+  <button type="submit" class="btn btn-primary" ng-show="$index<host.totalQuestions-1" ng-click="host.nextQuestion()">Next</button>
+  <button type="submit" class="btn btn-primary" ng-show="$index==host.totalQuestions-1" ui-sref="brave.host_review">Next</button>
 </div>

--- a/crossroads.net/app/group_finder/host/host_review.controller.js
+++ b/crossroads.net/app/group_finder/host/host_review.controller.js
@@ -1,0 +1,21 @@
+(function(){
+  'use strict';
+
+  module.exports = HostReviewCtrl;
+
+  HostReviewCtrl.$inject = ['$state', 'questions', 'Responses'];
+
+  function HostReviewCtrl($state, questions, Responses) {
+    var vm = this;
+
+    vm.questions = questions;
+    vm.responses = Responses;
+
+    vm.startOver = function(){
+      vm.currentQuestion = 1;
+      $state.go('brave.host', { step: vm.currentQuestion });
+    };
+
+  }
+
+})();

--- a/crossroads.net/app/group_finder/host/review.html
+++ b/crossroads.net/app/group_finder/host/review.html
@@ -1,0 +1,18 @@
+<div class="page-header">
+  <h2>Review</h2>
+</div>
+
+<div class="review">
+  <pre>
+  {{host.questions}}
+  </pre>
+
+  <pre>
+  {{host.responses}}
+  </pre>
+
+  <div class="btns">
+    <a class="btn btn-primary" href="#" ui-sref="brave.dashboard">Yes, this is correct</a>
+    <a class="btn btn-warning" href="#" ng-click="host.startOver()">No, I need to make some changes</a>
+  </div>
+</div>

--- a/crossroads.net/app/group_finder/index.js
+++ b/crossroads.net/app/group_finder/index.js
@@ -6,6 +6,7 @@
   require('./common/layout.html');
   require('./common/welcome.html');
   require('./host/host.html');
+  require('./host/review.html');
   require('./dashboard/dashboard.html');
   require('./summary/summary.html');
 
@@ -18,6 +19,7 @@
     .controller('GroupFinderCtrl',  require('./group_finder.controller'))
     .controller('DashboardCtrl',    require('./dashboard/dashboard.controller'))
     .controller('HostCtrl',         require('./host/host.controller'))
+    .controller('HostReviewCtrl',   require('./host/host_review.controller'))
     .controller('SummaryCtrl',      require('./summary/summary.controller'))
     ;
 

--- a/crossroads.net/app/group_finder/summary/summary.html
+++ b/crossroads.net/app/group_finder/summary/summary.html
@@ -29,5 +29,5 @@
 <div class="text-center" ng-show="summary.onLastSlide()">
   <hr />
   <a class="btn btn-primary" ui-sref="#">Join a Group</a>
-  <a class="btn btn-warning" ui-sref="brave.host">Host a Group</a>
+  <a class="btn btn-warning" ui-sref="brave.host({ step: 1 })">Host a Group</a>
 </div>


### PR DESCRIPTION
This PR implements a new ui-state at `/brave/host/review` so that we can distinguish the path from our stepped concierge questions. I'm also cleaning up our use of snake_case v. camelCase for consistency. Let me know if you have any questions. 

Thanks!
