### PR TITLE
Refactor QA flow for cleaner input validation.

### DIFF
--- a/crossroads.net/app/group_finder/data/host.questions.json
+++ b/crossroads.net/app/group_finder/data/host.questions.json
@@ -4,7 +4,8 @@
       "key": "location",
       "question": "What is your home address?",
       "model": "member",
-      "input_type": "address"
+      "input_type": "address",
+      "required": true
     },
     {
       "key": "group_name",

--- a/crossroads.net/app/group_finder/data/host.questions.json
+++ b/crossroads.net/app/group_finder/data/host.questions.json
@@ -1,8 +1,15 @@
 {
   "questions": [
     {
+      "key": "first_name",
+      "question": "What is your first name?",
+      "model": "member",
+      "input_type": "text",
+      "required": true
+    },
+    {
       "key": "location",
-      "question": "What is your home address?",
+      "question": "Ok {{responses.member.first_name}}, what is your home address?",
       "model": "member",
       "input_type": "address",
       "required": true

--- a/crossroads.net/app/group_finder/host/host.controller.js
+++ b/crossroads.net/app/group_finder/host/host.controller.js
@@ -8,9 +8,6 @@
                       '$log',
                       '$http',
                       '$cookies',
-                      '$stateParams',
-                      '$state',
-                      '$window',
                       'QuestionDefinitions',
                       'Responses',
                       'SERIES'
@@ -20,9 +17,6 @@
                     $log,
                     $http,
                     $cookies,
-                    $stateParams,
-                    $state,
-                    $window,
                     QuestionDefinitions,
                     Responses,
                     SERIES) {
@@ -31,41 +25,7 @@
 
     // Properties
     vm.questions = QuestionDefinitions.questions;
-    vm.totalQuestions = _.size(vm.questions);
-    vm.currentIteration = parseInt($stateParams.step) || 1;
     vm.responses = Responses.data;
-
-    // Methods
-    vm.previousQuestion = function() {
-      vm.currentIteration--;
-      $state.go(SERIES.permalink + '.host', { step: vm.currentIteration });
-    };
-
-    vm.nextQuestion = function() {
-      var req = vm.currentQuestion().required === true;
-      if (req && vm.responses[vm.currentQuestion().model][vm.currentKey()] === undefined) {
-        $window.alert('required');
-      } else {
-        vm.currentIteration++;
-        $state.go(SERIES.permalink + '.host', { step: vm.currentIteration });
-      }
-    };
-
-    vm.currentKey = function() {
-      return _.pluck(vm.questions, 'key')[vm.currentIteration - 1];
-    };
-
-    vm.currentQuestion = function() {
-      return vm.questions[vm.currentIteration - 1];
-    };
-
-    vm.startOver = function() {
-      vm.currentIteration = 1;
-    };
-
-    vm.reviewResponses = function() {
-      $state.go(SERIES.permalink + '.host_review');
-    };
   }
 
 })();

--- a/crossroads.net/app/group_finder/host/host.html
+++ b/crossroads.net/app/group_finder/host/host.html
@@ -2,10 +2,4 @@
   <h2>Host a Group</h2>
 </div>
 
-<div class="question" ng-repeat="(key, question) in host.questions track by $index" ng-show="(host.currentIteration-1)==$index">
-  <question definition="question" responses="host.responses"></question>
-  <hr />
-  <a href="#" class="btn btn-link" ng-hide="$index==0" ng-click="host.previousQuestion()">Go Back</a>
-  <button type="submit" class="btn btn-primary" ng-show="$index<host.totalQuestions-1" ng-click="host.nextQuestion()">Next</button>
-  <button type="submit" class="btn btn-primary" ng-show="$index==host.totalQuestions-1" ng-click="host.reviewResponses()">Next</button>
-</div>
+<questions responses="host.responses" definitions="host.questions" mode="host"></questions>

--- a/crossroads.net/app/group_finder/index.js
+++ b/crossroads.net/app/group_finder/index.js
@@ -13,6 +13,7 @@
   angular.module('crossroads.group_finder', [MODULES.CORE, MODULES.COMMON])
     .config(require('./group_finder.routes'))
     .constant('SERIES',             require('./group_finder.constants'))
+    .directive('questions',         require('./questions/questions.directive'))
     .directive('question',          require('./question/question.directive'))
     .factory('Group',               require('./services/group_finder.service'))
     .factory('GroupMember',         require('./services/group_member.service'))

--- a/crossroads.net/app/group_finder/question/input_address.html
+++ b/crossroads.net/app/group_finder/question/input_address.html
@@ -1,4 +1,4 @@
-<label>{{definition.question}}</label>
+<label ng-bind-html="renderedLabel()"></label>
 <div class="row">
   <div class="col-md-12">
     <label>Street</label>

--- a/crossroads.net/app/group_finder/question/input_address.html
+++ b/crossroads.net/app/group_finder/question/input_address.html
@@ -1,23 +1,22 @@
 <label>{{definition.question}}</label>
-
 <div class="row">
   <div class="col-md-12">
     <label>Street</label>
-    <input type="text" ng-model="responses[model()][definition.key].street" class="form-control" />
+    <input type="text" name="{{definition.key}}Street" ng-model="responses[model()][definition.key].street" class="form-control" ng-change="checkError()" />
   </div>
   <div class="col-md-5">
     <label>City</label>
-    <input class="form-control" type="text" ng-model="responses[model()][definition.key].city" />
+    <input type="text" name="{{definition.key}}City" ng-model="responses[model()][definition.key].city" class="form-control" ng-keyup="checkError()" />
   </div>
   <div class="col-md-4">
     <label>State</label>
-    <select ng-model="responses[model()][definition.key].state" class="form-control">
+    <select name="{{definition.key}}State" ng-model="responses[model()][definition.key].state" class="form-control" ng-change="checkError()">
       <option ng-repeat="state in states" value="{{state.abbreviation}}">{{state.name}}</option>
     </select>
   </div>
   <div class="col-md-3">
     <label>Zip</label>
-    <input type="text" class="form-control" ng-model="responses[model()][definition.key].zip" />
+    <input type="text" name="{{definition.key}}Zip" class="form-control" ng-model="responses[model()][definition.key].zip" ng-change="checkError()" />
   </div>
 </div>
 

--- a/crossroads.net/app/group_finder/question/input_checkbox.html
+++ b/crossroads.net/app/group_finder/question/input_checkbox.html
@@ -1,4 +1,4 @@
-<label>{{definition.question}}</label>
+<label ng-bind-html="renderedLabel()"></label>
 <div class="checkbox" ng-repeat="answer in definition.answers track by $index">
   <label>
     <input type="checkbox" name="{{definition.key}}" value="{{$index}}" checklist-value="$index" ng-model="responses[model()][definition.key][$index]" ng-change="checkError()" /> {{answer}}

--- a/crossroads.net/app/group_finder/question/input_checkbox.html
+++ b/crossroads.net/app/group_finder/question/input_checkbox.html
@@ -1,6 +1,6 @@
 <label>{{definition.question}}</label>
 <div class="checkbox" ng-repeat="answer in definition.answers track by $index">
   <label>
-    <input type="checkbox" value="{{$index}}" checklist-value="$index" ng-model="responses[model()][definition.key][$index]" /> {{answer}}
+    <input type="checkbox" name="{{definition.key}}" value="{{$index}}" checklist-value="$index" ng-model="responses[model()][definition.key][$index]" ng-change="checkError()" /> {{answer}}
   </label>
 </div>

--- a/crossroads.net/app/group_finder/question/input_number.html
+++ b/crossroads.net/app/group_finder/question/input_number.html
@@ -1,6 +1,6 @@
 <label>{{definition.question}}</label>
 <div class="text">
   <label>
-    <input type="number" min="0" value="{{$index}}" ng-model="responses[model()][definition.key]" class="form-control" />
+    <input type="number" name="{{definition.key}}" min="0" value="{{$index}}" ng-model="responses[model()][definition.key]" class="form-control" ng-change="checkError()" />
   </label>
 </div>

--- a/crossroads.net/app/group_finder/question/input_number.html
+++ b/crossroads.net/app/group_finder/question/input_number.html
@@ -1,4 +1,4 @@
-<label>{{definition.question}}</label>
+<label ng-bind-html="renderedLabel()"></label>
 <div class="text">
   <label>
     <input type="number" name="{{definition.key}}" min="0" value="{{$index}}" ng-model="responses[model()][definition.key]" class="form-control" ng-change="checkError()" />

--- a/crossroads.net/app/group_finder/question/input_radio.html
+++ b/crossroads.net/app/group_finder/question/input_radio.html
@@ -1,6 +1,6 @@
 <label>{{definition.question}}</label>
 <div class="radio" ng-repeat="answer in definition.answers track by $index">
   <label>
-    <input type="radio" value="{{$index}}" ng-model="responses[model()][definition.key]" /> {{answer}}
+    <input type="radio" name="{{definition.key}}" value="{{$index}}" ng-model="responses[model()][definition.key]" ng-change="checkError()" /> {{answer}}
   </label>
 </div>

--- a/crossroads.net/app/group_finder/question/input_radio.html
+++ b/crossroads.net/app/group_finder/question/input_radio.html
@@ -1,4 +1,4 @@
-<label>{{definition.question}}</label>
+<label ng-bind-html="renderedLabel()"></label>
 <div class="radio" ng-repeat="answer in definition.answers track by $index">
   <label>
     <input type="radio" name="{{definition.key}}" value="{{$index}}" ng-model="responses[model()][definition.key]" ng-change="checkError()" /> {{answer}}

--- a/crossroads.net/app/group_finder/question/input_select.html
+++ b/crossroads.net/app/group_finder/question/input_select.html
@@ -1,7 +1,7 @@
 <label>{{definition.question}}</label>
 <div class="text">
   <label>
-    <select ng-model="responses[model()][definition.key]" class="form-control">
+    <select name="{{definition.key}}" ng-model="responses[model()][definition.key]" class="form-control" ng-change="checkError()">
       <option ng-repeat="answer in definition.answers">{{answer}}</option>
     </select>
   </label>

--- a/crossroads.net/app/group_finder/question/input_select.html
+++ b/crossroads.net/app/group_finder/question/input_select.html
@@ -1,4 +1,4 @@
-<label>{{definition.question}}</label>
+<label ng-bind-html="renderedLabel()"></label>
 <div class="text">
   <label>
     <select name="{{definition.key}}" ng-model="responses[model()][definition.key]" class="form-control" ng-change="checkError()">

--- a/crossroads.net/app/group_finder/question/input_text.html
+++ b/crossroads.net/app/group_finder/question/input_text.html
@@ -1,2 +1,4 @@
-<label>{{definition.question}}</label>
-<input type="text" value="{{$index}}" ng-enter="submit()" ng-model="responses[model()][definition.key]" class="form-control" />
+<div class="form-group">
+  <label>{{definition.question}}</label>
+  <input type="text" name="{{definition.key}}" value="{{$index}}" ng-enter="submit()" ng-model="responses[model()][definition.key]" class="form-control" ng-change="checkError()" />
+</div>

--- a/crossroads.net/app/group_finder/question/input_text.html
+++ b/crossroads.net/app/group_finder/question/input_text.html
@@ -1,4 +1,4 @@
 <div class="form-group">
-  <label>{{definition.question}}</label>
+  <label ng-bind-html="renderedLabel()"></label>
   <input type="text" name="{{definition.key}}" value="{{$index}}" ng-enter="submit()" ng-model="responses[model()][definition.key]" class="form-control" ng-change="checkError()" />
 </div>

--- a/crossroads.net/app/group_finder/question/question.controller.js
+++ b/crossroads.net/app/group_finder/question/question.controller.js
@@ -19,6 +19,10 @@
       return 'question/input_'+ $scope.definition.input_type +'.html';
     };
 
+    $scope.checkError = function() {
+      $scope.$parent.applyErrors();
+    };
+
   }
 
 })();

--- a/crossroads.net/app/group_finder/question/question.controller.js
+++ b/crossroads.net/app/group_finder/question/question.controller.js
@@ -5,11 +5,12 @@
 
   var constants = require('./constants');
 
-  QuestionCtrl.$inject = ['$scope'];
+  QuestionCtrl.$inject = ['$scope', '$compile'];
 
-  function QuestionCtrl($scope) {
+  function QuestionCtrl($scope, $compile) {
 
     $scope.states = constants.US_STATES;
+    $scope.tpl = $compile('<span>' + $scope.definition.question + '<span>')($scope);
 
     $scope.model = function() {
       return $scope.definition.model;
@@ -21,6 +22,10 @@
 
     $scope.checkError = function() {
       $scope.$parent.applyErrors();
+    };
+
+    $scope.renderedLabel = function() {
+      return $scope.tpl.html();
     };
 
   }

--- a/crossroads.net/app/group_finder/questions/questions.controller.js
+++ b/crossroads.net/app/group_finder/questions/questions.controller.js
@@ -1,0 +1,79 @@
+(function(){
+  'use strict';
+
+  module.exports = QuestionsCtrl;
+
+  QuestionsCtrl.$inject = ['$scope', '$state', '$stateParams', '$window', 'SERIES'];
+
+  function QuestionsCtrl($scope, $state, $stateParams, $window, SERIES) {
+
+    // ------------------------ Properties
+
+    $scope.totalQuestions = _.size($scope.questions);
+    $scope.currentIteration = parseInt($stateParams.step) || 1;
+
+    // ------------------------ Methods
+
+    $scope.previousQuestion = function() {
+      $scope.currentIteration--;
+      $state.go(SERIES.permalink + '.' + $scope.mode, { step: $scope.currentIteration });
+    };
+
+    $scope.nextQuestion = function() {
+      if($scope.isRequired() && !_.isEmpty($scope.currentErrorFields())) {
+        $scope.applyErrors();
+      } else {
+        $scope.currentIteration++;
+        $state.go(SERIES.permalink + '.' + $scope.mode, { step: $scope.currentIteration });
+      }
+    };
+
+    $scope.currentKey = function() {
+      return _.pluck($scope.questions, 'key')[$scope.currentIteration - 1];
+    };
+
+    $scope.currentQuestion = function() {
+      return $scope.questions[$scope.currentIteration - 1];
+    };
+
+    $scope.startOver = function() {
+      $scope.currentIteration = 1;
+    };
+
+    $scope.reviewResponses = function() {
+      $state.go(SERIES.permalink + '.' + $scope.mode + '_review');
+    };
+
+    $scope.isRequired = function() {
+      return $scope.currentQuestion().required === true;
+    };
+
+    $scope.requiredFields = function() {
+      var visibleFields = $('input:visible, select:visible, textarea:visible');
+      return _.map(visibleFields, function(el,i) {
+        return $(el).attr('name');
+      });
+    };
+
+    $scope.currentErrorFields = function() {
+      return _.chain($scope.requiredFields())
+              .map(function(name) {
+                var el = $('[name=' + name + ']');
+                return el.val() === '' || el.val().indexOf('undefined') > -1 ? el : false;
+              })
+              .compact()
+              .value();
+    };
+
+    $scope.applyErrors = function() {
+      $('div.has-error:visible').removeClass('has-error');
+      _.each($scope.currentErrorFields(), function(el){
+        if(el.val() === '' || el.val().indexOf('undefined') > -1) {
+          el.closest('div').addClass('has-error');
+        }
+      });
+    };
+
+  }
+
+})();

--- a/crossroads.net/app/group_finder/questions/questions.directive.js
+++ b/crossroads.net/app/group_finder/questions/questions.directive.js
@@ -1,0 +1,23 @@
+(function(){
+  'use strict';
+
+  module.exports = QuestionsDirective;
+
+  require('./questions.html');
+
+  QuestionsDirective.$inject = ['$log'];
+
+  function QuestionsDirective($log) {
+    return {
+      restrict: 'AE',
+      scope: {
+        mode: '@mode',
+        questions: '=definitions',
+        responses: '=responses'
+      },
+      templateUrl: 'questions/questions.html',
+      controller: require('./questions.controller')
+    };
+  }
+
+})();

--- a/crossroads.net/app/group_finder/questions/questions.html
+++ b/crossroads.net/app/group_finder/questions/questions.html
@@ -1,0 +1,7 @@
+<div class="question" ng-repeat="(key, question) in questions track by $index" ng-show="(currentIteration-1)==$index">
+  <question definition="question" responses="responses"></question>
+  <hr />
+  <a href="#" class="btn btn-link" ng-hide="$index==0" ng-click="previousQuestion()">Go Back</a>
+  <button type="submit" class="btn btn-primary" ng-show="$index<totalQuestions-1" ng-click="nextQuestion()">Next</button>
+  <button type="submit" class="btn btn-primary" ng-show="$index==totalQuestions-1" ng-click="reviewResponses()">Next</button>
+</div>


### PR DESCRIPTION
@nogorilla – This PR does a few things... 
1. Creates a new "questions" directive to manage the entire QA flow. All methods & properties associated with that process (previous/next,etc) have been removed from the host controller and moved into this new directive. Now, implementing the member flow should be pretty easy. 
2. This PR updates the input validation stuff with Bootstrappy error classes. We now also have support for error states on individual input fields (i.e. all the fields under location). 
3. Finally solved the interpolated expression stuff via b4e2c49 so we should be good to reference anything within scope from our question labels. 
