### PR TITLE
#114065543 - Dashboard name bug fix

### DIFF
--- a/crossroads.net/app/group_finder/dashboard/dashboard.controller.js
+++ b/crossroads.net/app/group_finder/dashboard/dashboard.controller.js
@@ -76,7 +76,16 @@
     };
 
     vm.displayName = function() {
-      return vm.person.firstName + ' ' + vm.person.lastName[0] + '.';
+      var name;
+      if (vm.person) {
+        name = vm.person.firstName || '';
+
+        if (vm.person.lastName) {
+          name = name + ' ' + vm.person.lastName[0] + '.';
+        }
+      }
+
+      return name;
     };
 
     $scope.setGroup = function(group) {


### PR DESCRIPTION
This bug happens when a user logs in, closes the browser and reopens which wipes out the `userId` cookie.  The person data cannot be requested from the API without the cookie and the dashboard display name code breaks without a valid person object or populated last name
