### PR TITLE
Refactor Person Service and ui-router Resolves

### DIFF
--- a/crossroads.net/app/group_finder/dashboard/dashboard.controller.js
+++ b/crossroads.net/app/group_finder/dashboard/dashboard.controller.js
@@ -41,7 +41,7 @@
 
     vm.displayName = function() {
       var name;
-      if (vm.person && vm.person) {
+      if (vm.person) {
         name = vm.person.firstName || '';
 
         if (vm.person.lastName) {

--- a/crossroads.net/app/group_finder/dashboard/dashboard.controller.js
+++ b/crossroads.net/app/group_finder/dashboard/dashboard.controller.js
@@ -8,11 +8,11 @@
     '$scope',
     '$log',
     '$state',
-    'Person',
     'Email',
     '$modal',
     'ImageService',
-    'GroupInfo'
+    'GroupInfo',
+    'AuthenticatedPerson'
   ];
 
   function DashboardCtrl(
@@ -20,16 +20,16 @@
     $scope,
     $log,
     $state,
-    Person,
     Email,
     $modal,
     ImageService,
-    GroupInfo
+    GroupInfo,
+    AuthenticatedPerson
   ) {
 
     var vm = this;
 
-    vm.person = Person.getProfile();
+    vm.person = AuthenticatedPerson;
     vm.profileImageBaseUrl = ImageService.ProfileImageBaseURL;
     vm.profileImage = vm.profileImageBaseUrl + vm.person.contactId;
     vm.defaultImage = ImageService.DefaultProfileImage;
@@ -41,7 +41,7 @@
 
     vm.displayName = function() {
       var name;
-      if (vm.person) {
+      if (vm.person && vm.person) {
         name = vm.person.firstName || '';
 
         if (vm.person.lastName) {
@@ -59,7 +59,6 @@
     $rootScope.$on('$viewContentLoading', function(event){
       vm.group = undefined;
     });
-
   }
 
 })();

--- a/crossroads.net/app/group_finder/dashboard/dashboard.routes.js
+++ b/crossroads.net/app/group_finder/dashboard/dashboard.routes.js
@@ -13,9 +13,6 @@
         url: '/dashboard',
         templateUrl: 'dashboard/dashboard.html',
         controller: 'DashboardCtrl as dashboard',
-        resolve: {
-          GroupInfo: 'GroupInfo'
-        },
         data: {
           isProtected: true,
           meta: {

--- a/crossroads.net/app/group_finder/dashboard/dashboard.routes.js
+++ b/crossroads.net/app/group_finder/dashboard/dashboard.routes.js
@@ -13,6 +13,12 @@
         url: '/dashboard',
         templateUrl: 'dashboard/dashboard.html',
         controller: 'DashboardCtrl as dashboard',
+        resolve: {
+          AuthenticatedPerson: ['Person', function(Person) {
+            console.log("Dashboard Person Resolve");
+            return Person.getProfile();
+          }]
+        },
         data: {
           isProtected: true,
           meta: {

--- a/crossroads.net/app/group_finder/directives/question/question.controller.js
+++ b/crossroads.net/app/group_finder/directives/question/question.controller.js
@@ -17,11 +17,17 @@
       $scope.help = $compile('<span>' + $scope.definition.help + '<span>')($scope);
       $scope.footer = $compile('<span>' + $scope.definition.footer + '<span>')($scope);
 
-      $scope.person = Person.getProfile();
-      $scope.profileImage = ImageService.ProfileImageBaseURL + $scope.person.contactId;
+      $scope.person = null;
+      $scope.profileImage = ImageService.DefaultProfileImage;
       $scope.defaultImage = ImageService.DefaultProfileImage;
 
       $scope.setupSlider();
+
+      // Load the person data
+      Person.getProfile().then(function(profile) {
+        $scope.profileImage = ImageService.ProfileImageBaseURL + $scope.person.contactId;
+        $scope.person = profile;
+      })
     };
 
     $scope.setupSlider = function() {

--- a/crossroads.net/app/group_finder/group_finder.routes.js
+++ b/crossroads.net/app/group_finder/group_finder.routes.js
@@ -14,9 +14,8 @@
         controller: 'GroupFinderCtrl as base',
         templateUrl: 'common/layout.html',
         resolve: {
-          AuthenticatedPerson: ['Person', function(Person) {
-            console.log("Dashboard Person Resolve");
-            return Person.getProfile();
+          StartProfileLoad: ['Person', function(Person) {
+            Person.loadProfile();
           }]
         },
         data: {

--- a/crossroads.net/app/group_finder/group_finder.routes.js
+++ b/crossroads.net/app/group_finder/group_finder.routes.js
@@ -14,12 +14,9 @@
         controller: 'GroupFinderCtrl as base',
         templateUrl: 'common/layout.html',
         resolve: {
-          First: ['Person', '$cookies', function(Person, $cookies) {
-            console.log('GroupFinder resolve');
-            var cid = $cookies.get('userId');
-            if (cid) {
-              Person.loadProfile(cid);
-            }
+          AuthenticatedPerson: ['Person', function(Person) {
+            console.log("Dashboard Person Resolve");
+            return Person.getProfile();
           }]
         },
         data: {

--- a/crossroads.net/app/group_finder/host/host.controller.js
+++ b/crossroads.net/app/group_finder/host/host.controller.js
@@ -3,11 +3,11 @@
 
   module.exports = HostCtrl;
 
-  HostCtrl.$inject = ['$timeout', '$scope', '$state', 'Person'];
+  HostCtrl.$inject = ['$timeout', '$scope', '$state', 'AuthenticatedPerson'];
 
-  function HostCtrl ($timeout, $scope, $state, Person) {
+  function HostCtrl ($timeout, $scope, $state, AuthenticatedPerson) {
     $scope.currentStep = 1;
-    $scope.person = Person;
+    $scope.person = AuthenticatedPerson;
   }
 
 })();

--- a/crossroads.net/app/group_finder/host/host.routes.js
+++ b/crossroads.net/app/group_finder/host/host.routes.js
@@ -13,9 +13,10 @@
         url: '/host',
         templateUrl: 'host/host.html',
         resolve: {
-          Profile: 'Profile',
-          Person: 'Person',
-          GroupQuestionService: 'GroupQuestionService',
+          AuthenticatedPerson: ['Person', function(Person) {
+            console.log("Dashboard Person Resolve");
+            return Person.getProfile();
+          }],
           QuestionDefinitions: function(GroupQuestionService) {
             return GroupQuestionService.get().$promise;
           }

--- a/crossroads.net/app/group_finder/join/join.controller.js
+++ b/crossroads.net/app/group_finder/join/join.controller.js
@@ -3,11 +3,11 @@
 
   module.exports = JoinCtrl;
 
-  JoinCtrl.$inject = ['$scope', 'Person'];
+  JoinCtrl.$inject = ['$scope', 'AuthenticatedPerson'];
 
-  function JoinCtrl ($scope, Person) {
+  function JoinCtrl ($scope, AuthenticatedPerson) {
     $scope.currentStep = 1;
-    $scope.person = Person;
+    $scope.person = AuthenticatedPerson;
   }
 
 })();

--- a/crossroads.net/app/group_finder/join/join.routes.js
+++ b/crossroads.net/app/group_finder/join/join.routes.js
@@ -13,9 +13,10 @@
         url: '/join',
         templateUrl: 'join/join.html',
         resolve: {
-          Profile: 'Profile',
-          Person: 'Person',
-          ParticipantQuestionService: 'ParticipantQuestionService',
+          AuthenticatedPerson: ['Person', function(Person) {
+            console.log("Dashboard Person Resolve");
+            return Person.getProfile();
+          }],
           QuestionDefinitions: function(ParticipantQuestionService) {
             return ParticipantQuestionService.get().$promise;
           }

--- a/crossroads.net/app/group_finder/services/person.service.js
+++ b/crossroads.net/app/group_finder/services/person.service.js
@@ -3,24 +3,60 @@
 
   module.exports = PersonService;
 
-  PersonService.$inject = ['Profile'];
+  PersonService.$inject = ['$rootScope', '$cookies', 'Profile', 'AUTH_EVENTS', '$log'];
 
-  function PersonService(Profile) {
-    var person = {};
+  function PersonService($rootScope, $cookies, Profile, AUTH_EVENTS, $log) {
+    var promise = null;
 
-    person.loadProfile = function(cid) {
-      if (cid) {
-        Profile.Person.get({contactId: cid}, function(data) {
-          console.log('PersonService', data);
-          person = data;
-        });
+    //
+    // Authenticated Person Info Service
+    //
+
+    var service = {};
+    service.getProfile = getProfile;
+
+    //
+    // Listen for the logout event notification to clear the data
+    //
+
+    $rootScope.$on(AUTH_EVENTS.logoutSuccess, clearData);
+
+    //
+    // Service Implementation
+    //
+
+    function loadProfile() {
+      if (!promise) {
+        var cid = $cookies.get('userId');
+        if (cid) {
+          $log.debug('PersonService - load profile for', cid);
+          promise = Profile.Person.get({contactId: cid}).$promise;
+
+          promise.then(function(data) {
+            $log.debug('PersonService - profile loaded', data);
+            service.profile = data;
+          });
+        }
       }
-    };
 
-    person.getProfile = function() {
-      return person;
-    };
+      return promise;
+    }
 
-    return person;
+    function getProfile() {
+      var loadPromise = loadProfile();
+      return loadPromise.then(function() {
+        $log.debug('PersonService.getProfile() return authenticated profile');
+        return service.profile;
+      });
+    }
+
+    function clearData() {
+      $log.debug('Clear Group Profile data for logged in user');
+      promise = null;
+      delete service.profile;
+    }
+
+    // Return the service instance
+    return service;
   }
 })();

--- a/crossroads.net/app/group_finder/services/person.service.js
+++ b/crossroads.net/app/group_finder/services/person.service.js
@@ -13,6 +13,7 @@
     //
 
     var service = {};
+    service.loadProfile = loadProfile;
     service.getProfile = getProfile;
 
     //


### PR DESCRIPTION
- This solves for the bug in which the logged in user profile is not immediately available when the browser page is reloaded and the display name is unavailable on the dashboard
- Refactor the Person Service so that the getProfile() call is wrapped in a promise to handle asynchronous data request.  If loadProfile() is called earlier, the data will be immediately available, otherwise loadProfile will be called by getProfile() to cache the data
- Inject the resolved 'AuthenticatedPerson' into the sub-route parents group_finder.dashboard/group_finder.dashboard.host/group_finder.dashboard.join so that it will be available to all authenticated sub-states.  This is the preferred way for ui-router states to handle the data since they won't have to manually manage the getProfile() promise
- Question directive controller must resolve the Person.getProfile() directly since it can't receive a route injectable parameter
